### PR TITLE
update copr-chunk RFC to adapt latest requirements

### DIFF
--- a/text/0043-copr-chunk.md
+++ b/text/0043-copr-chunk.md
@@ -1,4 +1,7 @@
-# RFC: Using chunk format in coprocessor framework
+# Using chunk format in coprocessor framework
+
+* RFC PR: https://github.com/tikv/rfcs/pull/43
+* Tracking Issue: https://github.com/tikv/tikv/issues/7724
 
 ## Summary
 


### PR DESCRIPTION
https://github.com/tikv/rfcs/pull/43 was proposed on Mar 8, 2020 and merged just now. Until then did I find that the format of RFC has been changed. This PR adapts copr-chunk RFC to latest requirements.

Signed-off-by: Alex Chi <iskyzh@gmail.com>