### PR TITLE
fix deleted mark in `0069-api-v2.md`

### DIFF
--- a/text/0069-api-v2.md
+++ b/text/0069-api-v2.md
@@ -63,7 +63,7 @@ The value of RawKV `API V2` by now can be either:
 
 1. `{data}{0x0}`, for values without TTL
 2. `{data}{TTL expire timestamp}{0x1}`, for values with TTL
-3. `{0x1}`, for values deleted
+3. `{0x2}`, for values deleted
 
 The last byte of value is used as meta flags. Bit `0` of flag is for TTL, if it's set, the `8` bytes just before meta flags is the TTL expire timestamp. Bit `1` is for deleted mark, if it's set, the entries is logically deleted (used for [Change Data Capture]).
 


### PR DESCRIPTION
The delete mark should be `{0x2}` instead of `{0x1}`